### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/Aysher-Intelligence-Agency/EDGAR2/security/code-scanning/1](https://github.com/Aysher-Intelligence-Agency/EDGAR2/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs that do not have their own `permissions` key, ensuring that the `GITHUB_TOKEN` permissions are limited to the least privilege required. Specifically, set `contents: read` at the root level, as this is sufficient for the `build` job. The `publish-gpr` job already has its own `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
